### PR TITLE
fix(destroy): removed task clean-aap from destroy playbook

### DIFF
--- a/sno_on_kubevirt/roles/sno_on_kubevirt/tasks/destroy.yml
+++ b/sno_on_kubevirt/roles/sno_on_kubevirt/tasks/destroy.yml
@@ -13,8 +13,8 @@
   ansible.builtin.include_tasks: destroy-dns.yml
   tags: dns
 
-- name: Update AAP documentation
-  ansible.builtin.include_tasks: clean-aap.yml
+# - name: Update AAP documentation
+#   ansible.builtin.include_tasks: clean-aap.yml
 
 - name: Destroy agent iso
   ansible.builtin.include_tasks: destroy-agent-iso.yml


### PR DESCRIPTION
This task is not necessary as it tried to add credentials and hosts which are already present from the create task